### PR TITLE
chore(deps): bump Micronaut to 5.0.6 and gru to 3.0.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ mavenCentralPublishPluginVersion = 0.34.0
 develocityPluginVersion = 4.2.2
 gitPublishPluginVersion=2.1.3
 
-micronautVersion = 5.0.0
-micronautGradlePluginVersion = 5.0.0
-gruVersion = 3.0.0.RC2
+micronautVersion = 5.0.6
+micronautGradlePluginVersion = 5.0.2
+gruVersion = 3.0.0
 boltVersion = 1.36.1


### PR DESCRIPTION
Bumps Micronaut to 5.0.6, the Micronaut Gradle plugin to 5.0.2, and gru to the 3.0.0 GA (was 3.0.0.RC2). Part of the MN 5.0.6 OSS release train (ships as micronaut-slack 3.0.0 GA).