### PR TITLE
chore(deps): bump Micronaut to 5.1.0 and fix guide title attributes

### DIFF
--- a/docs/guide/guide.gradle
+++ b/docs/guide/guide.gradle
@@ -34,6 +34,9 @@ asciidoctor {
         'gradle-version': project.gradle.gradleVersion,
         'source-highlighter': 'prettify',
         'root-dir': rootDir,
-        'project-slug': slug
+        'project-slug': slug,
+        'project-title': 'Micronaut Slack',
+        'project-version': project.version,
+        'project-author': 'Agorapulse'
     ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,5 +31,5 @@ gitPublishPluginVersion=2.1.3
 
 micronautVersion = 5.1.0
 micronautGradlePluginVersion = 5.0.2
-gruVersion = 3.0.0
+gruVersion = 3.0.2
 boltVersion = 1.36.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ mavenCentralPublishPluginVersion = 0.34.0
 develocityPluginVersion = 4.2.2
 gitPublishPluginVersion=2.1.3
 
-micronautVersion = 5.0.6
+micronautVersion = 5.1.0
 micronautGradlePluginVersion = 5.0.2
 gruVersion = 3.0.0
 boltVersion = 1.36.1


### PR DESCRIPTION
Bumps Micronaut 5.0.6 -> 5.1.0 (plugin stays 5.0.2) and fixes the guide literal {project-title}/{project-version}. Ships as micronaut-slack 3.0.1.